### PR TITLE
modify docker file

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM golang:alpine as builder
 RUN mkdir /build
 ADD . /build/
 WORKDIR /build
-RUN CGO_ENABLED=0 GOOS=linux go build -mod vendor -a -installsuffix cgo -ldflags '-extldflags "-static"' -o falco-eks-audit-bridge . && \
+RUN apk add -U --no-cache git
+RUN CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -ldflags '-extldflags "-static"' -o falco-eks-audit-bridge . && \
     apk add -U --no-cache ca-certificates
 
 FROM scratch


### PR DESCRIPTION
## 背景

make dockerを実行しても、vendor/に必要なmodを入れておかないとbuildできない

## やったこと

modのinstallもdocker内で実行するようにして、make dockerだけでdocker buildできるようにする

## 検証

make dockerコマンドを実行してbuildできる